### PR TITLE
two braces were missing in core.py

### DIFF
--- a/engine/core.py
+++ b/engine/core.py
@@ -72,7 +72,7 @@ class Ubbr(object):
         template +=template_fragments.pop(0)
         counter = 0
         while len(template_fragments)>0:
-            template +="{{ {var_name}.".format(var_name=self.context_variable_name)+str(counter)+" }}"+template_fragments.pop(0)
+            template +="{{{{ {var_name}.".format(var_name=self.context_variable_name)+str(counter)+" }}"+template_fragments.pop(0)
             counter+=1
         return [template,code_fragments]
 


### PR DESCRIPTION
the expected output is "{{..."
since "..".format() is used, one has to enter four braces to get there

Without this change, the browser shows, e.g., 

{ ubbrvalues.0 }}

note that there is only one opening brace; thus the templating engine is not invoked